### PR TITLE
Fix .NET Version in Azure Cloud Shell

### DIFF
--- a/src/HotelReservationSystemTestClient/HotelReservationSystemTestClient.csproj
+++ b/src/HotelReservationSystemTestClient/HotelReservationSystemTestClient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
###  [last edit: Aug. 29, 2023]
The Cloud Shell is not compatible with this framework version. To resolve this issue, update the .NET version to 7.0.

Environment: Azure Cloud Shell

### **Reproduce error environment:**

1. Upload a .NET webpage to the WebApp.

    `git clone https://github.com/MicrosoftDocs/mslearn-hotel-reservation-system.git`
    `cd mslearn-hotel-reservation-system/src`
    `dotnet build`
    `cd HotelReservationSystem`
    `dotnet publish -o website`
    `cd website`
    `zip website.zip *`
    `az webapp deployment source config-zip --src website.zip --name <your-webapp-name> --resource-group <your-rg-name>`


2. Configure WebApp URL.
    `cd ~/mslearn-hotel-reservation-system/src/HotelReservationSystemTestClient`
    `code App.config`
    `### Continue Setting Configuration for WebApp url ###`

3. Based on the hint in Microsoft Learn and the issue in this repository, change the .NET version to 6.0.
    `code HotelReservationSystemTestClient.csproj`
    `### Setting TargetFramework from netcoreapp2.1 to netcoreapp6.0 ###`

4. After running `dotnet build` and `dotnet run`, you may receive the following error log:

```
You must install or update .NET to run this application.

App: /home/yan-hui/mslearn-hotel-reservation-system/src/HotelReservationSystemTestClient/bin/Debug/netcoreapp6.0/HotelReservationSystemTestClient
Architecture: x64
Framework: 'Microsoft.NETCore.App', version '6.0.0' (x64)
.NET location: /usr/share/dotnet

The following frameworks were found:
  7.0.9 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]
  7.0.10 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]

Learn about framework resolution:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=6.0.0&arch=x64&rid=mariner.2.0-x64
```


### **Solution:**
Install .Net 7
Reference:  [dotnet-install](https://learn.microsoft.com/zh-tw/dotnet/core/install/linux-scripted-manual#manual-install)

1. Install Package

    `wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh`
    `chmod +x ./dotnet-install.sh`
    `./dotnet-install.sh --channel 7.0`

3. Change the .NET version to 7.0.
    `code HotelReservationSystemTestClient.csproj`
    `### Setting TargetFramework from netcoreapp6.0 to netcoreapp7.0 ###`

4. After installing .NET 7, you can continue to perform flow tests.
    `dotnet build`
    `dotnet run`

